### PR TITLE
Fix subtle logic error with domain validation records

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,14 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 1
 
       - name: terraform setup
-        uses: hashicorp/setup-terraform@v1
-        with:
-          terraform_version: 0.12.29
+        uses: hashicorp/setup-terraform@v2
+      # with:
       #   cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 
 #     TODO: This step duplicates work done by the Makefile.

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ locals {
   fqdn                    = var.hostname != "" ? format("%s.%s", var.hostname, var.domain) : var.domain
   san                     = formatlist("%s.%s", var.subject_alternative_names, var.domain)
   skip_route53_validation = var.validation_method == "EMAIL" ? true : var.skip_route53_validation
-  create_route53_record   = var.create_route53_record && false == local.skip_route53_validation
+  create_route53_record   = var.create_route53_record && (!local.skip_route53_validation)
 }
 
 data "aws_route53_zone" "default" {
@@ -25,7 +25,7 @@ resource "aws_acm_certificate" "default" {
 }
 
 locals {
-  dvo_data = (! local.create_route53_record) ? {} : {
+  dvo_data = (!local.create_route53_record) ? {} : {
     for dvo in aws_acm_certificate.default.domain_validation_options : dvo.domain_name => {
       name   = dvo.resource_record_name
       record = dvo.resource_record_value

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,3 +7,11 @@ output "domain_validation_options" {
   description = "A list of attributes to used to complete certificate validation."
   value       = aws_acm_certificate.default.domain_validation_options
 }
+
+output "_create_route53_record" {
+  value = var._debug ? local.create_route53_record : null
+}
+
+output "_local_skip_route53_validation" {
+  value = var._debug ? local.skip_route53_validation : null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,20 @@ variable "tags" {
 
 variable "skip_route53_validation" {
   description = "Set to true for zones not hosted in Route53"
+  type        = bool
   default     = false
 }
 
 variable "create_route53_record" {
   description = "Set to false if Route53 record already exists"
+  type        = bool
   default     = true
+}
+
+# Debugging.
+
+variable "_debug" {
+  description = "Produce debug output (boolean)"
+  type        = bool
+  default     = false
 }


### PR DESCRIPTION
Between a variable not correctly declared as bool, and an odd conditional clause in a local variable, the module was attempting to incorrectly destroy domain validation records.